### PR TITLE
Don't connect to setlist.fm if no API key

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ To run the server locally with full functionality, there are 5 environment varia
 3. DEPLOY_STAGE - this is used internally for switching between production and development logic  
     - Set this to `DEV`  
 4. SETLIST_FM_API_KEY - the API key for accessing the setlist FM API  
-    - If you have no intention of using the "Recent setlists" track type, you can set this to any trash value, as long as it's set, and you don't need to create a setlist dev account  
+    - If you are not in PROD and have no intention of using the "Recent setlists" track type, you can leave this empty and API calls won't be made  
     - Create a setlist.fm regular account  
     - Navigate to their [apps page](https://www.setlist.fm/settings/apps) and apply for an API key  
     - Once they approve (pretty quick turnaround) use the API key shown on the apps page as the value for SETLIST_FM_API_KEY  

--- a/src/setlist-fm-helper.ts
+++ b/src/setlist-fm-helper.ts
@@ -3,6 +3,11 @@ import {instrumentCall} from "./helpers";
 const baseUrl = "https://api.setlist.fm/rest/1.0/";
 
 async function getArtistSetlists(artistMbid: string): Promise<SetlistFmSetlist[]> {
+
+    if (process.env.DEPLOY_STAGE !== 'PROD' &&
+       (!process.env.SETLIST_FM_API_KEY || process.env.SETLIST_FM_API_KEY === ""))
+        return [];
+
     const url  = `${baseUrl}artist/${artistMbid}/setlists`;
     const opts = {
         headers : {

--- a/src/setlist-fm-helper.ts
+++ b/src/setlist-fm-helper.ts
@@ -5,8 +5,9 @@ const baseUrl = "https://api.setlist.fm/rest/1.0/";
 async function getArtistSetlists(artistMbid: string): Promise<SetlistFmSetlist[]> {
 
     if (process.env.DEPLOY_STAGE !== 'PROD' &&
-       (!process.env.SETLIST_FM_API_KEY || process.env.SETLIST_FM_API_KEY === ""))
+       (!process.env.SETLIST_FM_API_KEY || process.env.SETLIST_FM_API_KEY === "")) {
         return [];
+    }
 
     const url  = `${baseUrl}artist/${artistMbid}/setlists`;
     const opts = {


### PR DESCRIPTION
I don't have a setlist.fm key and for testing purposes don't need one. This minor change makes it easier to run locally without slowing things down by continuously getting 403s from setlist.fm because of a missing API key.