### PR TITLE
Fix crash if no festival data in cache

### DIFF
--- a/src/redis-helper.ts
+++ b/src/redis-helper.ts
@@ -19,6 +19,11 @@ export async function getArtistsForFestival(redisClient: redis.RedisClient, fest
 
     const days: string[] = await daysPromise;
 
+    if (!days) {
+        console.error(`Tried to view a festival ${festivalName} ${festivalYear} with no days`);
+        return [];
+    }
+
     const redisArtistPromises: Promise<any>[] = [];
     for (const day of days) {
         if (day === undefined || day === "") {


### PR DESCRIPTION
Closes #32 

This is a fairly naive fix in that it just avoids the crash. It results in the user seeing a customise page with no artists. It will log and error to the console.

Ideally we'd avoid this upfront e.g. by only showing festivals in the homepage dropdown in the first place if they have at least 1 artist. But adding that check to every boot or page load isn't that attractive and this code change provides extra safety anyway.