### PR TITLE
Add extra comma detection to warm cache script

### DIFF
--- a/src/warm-cache-for-festival.ts
+++ b/src/warm-cache-for-festival.ts
@@ -23,7 +23,7 @@ async function warm(festival: string, years: number[]) {
             mtime = statSync(`../lineups/${filename}`).mtime;
         } else {
             console.error(`File ${filename} not found`);
-            return;
+            process.exit(1);
         }
 
         const artistLines                           = file.split('\n');
@@ -37,6 +37,11 @@ async function warm(festival: string, years: number[]) {
             const artistDetails: string[] = artistLine.split(",");
             const artistName              = artistDetails[0];
             let   day                     = artistDetails[1];
+
+            if (artistDetails.length > 2) {
+                console.error(`Line appears to contain too many commas - ${artistDetails}`);
+                process.exit(1);
+            }
 
             // If we don't have days in our text file yet, list everything under day zero
             if (!day) {


### PR DESCRIPTION
Because I'd rather crash the warm cache script early and be confident I've not slipped a comma in, given how much of a mess it makes.

I found that just using `return;` to bug out causes the script to hang in Node (probably because the Redis connection is still open) so changed to `process.exit(1);`, and did the same on the file not found check as well. Can change if required.

I've tested this by randomly adding commas at the start and end of line and the script correctly bugs out.