### PR TITLE
Update bonnaroo_2026.yaml

### DIFF
--- a/lineups/bonnaroo_2026.yaml
+++ b/lineups/bonnaroo_2026.yaml
@@ -89,6 +89,14 @@ days:
         spotify_uri: 5ykY9Uweo3gl5VFpb6z6pQ
       - name: PAWPAW ROD
         spotify_uri: 23KIrX6iPiVOkx60F4bjNq
+      - name: EAZYBAKED
+        spotify_uri: 1ZbT8FIqEc0cktnu6mNlvv
+      - name: LUMASI
+        spotify_uri: 0y5sfSvE19x3r3nVUKYbIN
+      - name: MARY DROPPINZ
+        spotify_uri: 4tPVnr7VB15UA9TRsie3cS
+      - name: PROBCAUSE
+        spotify_uri: 1ZcfGrGrm9aHnUNVQz3sCY
   - number: 3
     date: 2026-06-13
     display_name: Day 3
@@ -165,6 +173,14 @@ days:
         spotify_uri: 0Kc65Qv0ju9H2cMNnP3Tqd
       - name: '"WEIRD AL" YANKOVIC'
         spotify_uri: 1bDWGdIC2hardyt55nlQgG
+      - name: BIG GIGANTIC
+        spotify_uri: 7o7mC95EDbJKTcPAAs8C3r
+      - name: CLOZEE
+        spotify_uri: 1496XxkytEk26FUJLfpVZr
+      - name: EFFIN
+        spotify_uri: 6l0u1oM2imxw0isrGcXpmH
+      - name: SMOAKLAND
+        spotify_uri: 6409kgOB4tZEkNZci6BiUs
   - number: 4
     date: 2026-06-14
     display_name: Day 4

--- a/lineups/bonnaroo_2026.yaml
+++ b/lineups/bonnaroo_2026.yaml
@@ -97,6 +97,10 @@ days:
         spotify_uri: 4tPVnr7VB15UA9TRsie3cS
       - name: PROBCAUSE
         spotify_uri: 1ZcfGrGrm9aHnUNVQz3sCY
+      - name: GANJA WHITE NIGHT
+        spotify_uri: 1a6oIpEh4DGgaqgWg5xwd3
+      - name: INZO
+        spotify_uri: 18Eu7uJEMPWwwt1QUdCglQ
   - number: 3
     date: 2026-06-13
     display_name: Day 3
@@ -239,3 +243,5 @@ days:
         spotify_uri: 1Tq0nryXkwLARcHDMIZbY6
       - name: MOTIFV
         spotify_uri: 3Q3g3xC2lDdLo3a04uK3Wp
+      - name: NAT MYERS
+        spotify_uri: 2QMlNryks9wyxBCsBGciTS


### PR DESCRIPTION
Add recently announced [Where stage lineup](https://www.bonnaroo.com/lineup)

<details>
<summary>node dist/src/warm-cache-for-festival.js bonnaroo 2026</summary>

```text
Loading file lineups/bonnaroo_2026.yaml
Getting spotify API token...
Reply: OK
Reply: OK
Received 4 artists from 4 lineup artists
Received 39 artists from 39 lineup artists
Received 40 artists from 40 lineup artists
Received 27 artists from 27 lineup artists
-------------------------------
Received 4 artists from 4 lineup artists
festival:bonnaroo_2026:1
Reply: OK
Warming cache for day 1/4 for artist 1/4...
Have top track ids for artist Skrillex (5he5w2lnU9x7JFhnwcekXX)
Have setlist track ids for artist Skrillex (5he5w2lnU9x7JFhnwcekXX)
Have newest track ids for artist 5he5w2lnU9x7JFhnwcekXX
Warming cache for day 1/4 for artist 2/4...
Have top track ids for artist Four Tet (7Eu1txygG6nJttLHbZdQOh)
Have setlist track ids for artist Four Tet (7Eu1txygG6nJttLHbZdQOh)
Have top track ids for artist Four Tet (7Eu1txygG6nJttLHbZdQOh)
Have newest track ids for artist 7Eu1txygG6nJttLHbZdQOh
Warming cache for day 1/4 for artist 3/4...
Have top track ids for artist Vince Staples (68kEuyFKyqrdQQLLsmiatm)
Have setlist track ids for artist Vince Staples (68kEuyFKyqrdQQLLsmiatm)
Have newest track ids for artist 68kEuyFKyqrdQQLLsmiatm
Warming cache for day 1/4 for artist 4/4...
Have top track ids for artist Spiritual Cramp (6cpzd2aRLmkE06P4lFFMlj)
Have setlist track ids for artist Spiritual Cramp (6cpzd2aRLmkE06P4lFFMlj)
Have newest track ids for artist 6cpzd2aRLmkE06P4lFFMlj
Received 39 artists from 39 lineup artists
festival:bonnaroo_2026:2
Reply: OK
Warming cache for day 2/4 for artist 1/39...
Have top track ids for artist The Strokes (0epOFNiUfyON9EYx7Tpr6V)
Have setlist track ids for artist The Strokes (0epOFNiUfyON9EYx7Tpr6V)
Have newest track ids for artist 0epOFNiUfyON9EYx7Tpr6V
Warming cache for day 2/4 for artist 2/39...
Have top track ids for artist GRiZ (25oLRSUjJk4YHNUsQXk7Ut)
Have setlist track ids for artist GRiZ (25oLRSUjJk4YHNUsQXk7Ut)
Have newest track ids for artist 25oLRSUjJk4YHNUsQXk7Ut
Warming cache for day 2/4 for artist 3/39...
Have top track ids for artist Turnstile (2qnpHrOzdmOo1S4ox3j17x)
Have setlist track ids for artist Turnstile (2qnpHrOzdmOo1S4ox3j17x)
Have newest track ids for artist 2qnpHrOzdmOo1S4ox3j17x
Warming cache for day 2/4 for artist 4/39...
Have top track ids for artist Mt. Joy (69tiO1fG8VWduDl3ji2qhI)
Have setlist track ids for artist Mt. Joy (69tiO1fG8VWduDl3ji2qhI)
Have newest track ids for artist 69tiO1fG8VWduDl3ji2qhI
Warming cache for day 2/4 for artist 5/39...
Have top track ids for artist Major Lazer (738wLrAtLtCtFOLvQBXOXp)
Have setlist track ids for artist Major Lazer (738wLrAtLtCtFOLvQBXOXp)
Have top track ids for artist Major Lazer (738wLrAtLtCtFOLvQBXOXp)
Have newest track ids for artist 738wLrAtLtCtFOLvQBXOXp
Warming cache for day 2/4 for artist 6/39...
Have top track ids for artist Jessie Murph (2yLzlEFtIS0Q9UkyBZdQA7)
Have setlist track ids for artist Jessie Murph (2yLzlEFtIS0Q9UkyBZdQA7)
Have newest track ids for artist 2yLzlEFtIS0Q9UkyBZdQA7
Warming cache for day 2/4 for artist 7/39...
Have top track ids for artist YUNGBLUD (6Ad91Jof8Niiw0lGLLi3NW)
Have setlist track ids for artist YUNGBLUD (6Ad91Jof8Niiw0lGLLi3NW)
Have newest track ids for artist 6Ad91Jof8Niiw0lGLLi3NW
Warming cache for day 2/4 for artist 8/39...
Have top track ids for artist Geese (0WCo84qtCKfbyIf1lqQWB4)
Have setlist track ids for artist Geese (0WCo84qtCKfbyIf1lqQWB4)
Have newest track ids for artist 0WCo84qtCKfbyIf1lqQWB4
Warming cache for day 2/4 for artist 9/39...
Have top track ids for artist Cloonee (7MdlXmq2HViAJWo9cf30sR)
Have setlist track ids for artist Cloonee (7MdlXmq2HViAJWo9cf30sR)
Have top track ids for artist Cloonee (7MdlXmq2HViAJWo9cf30sR)
Have newest track ids for artist 7MdlXmq2HViAJWo9cf30sR
Warming cache for day 2/4 for artist 10/39...
Have top track ids for artist Lil Jon (7sfl4Xt5KmfyDs2T3SVSMK)
Have setlist track ids for artist Lil Jon (7sfl4Xt5KmfyDs2T3SVSMK)
Have top track ids for artist Lil Jon (7sfl4Xt5KmfyDs2T3SVSMK)
Have newest track ids for artist 7sfl4Xt5KmfyDs2T3SVSMK
Warming cache for day 2/4 for artist 11/39...
Have top track ids for artist Blood Orange (6LEeAFiJF8OuPx747e1wxR)
Have setlist track ids for artist Blood Orange (6LEeAFiJF8OuPx747e1wxR)
Have top track ids for artist Blood Orange (6LEeAFiJF8OuPx747e1wxR)
Have newest track ids for artist 6LEeAFiJF8OuPx747e1wxR
Warming cache for day 2/4 for artist 12/39...
Have top track ids for artist Wet Leg (2TwOrUcYnAlIiKmVQkkoSZ)
Have setlist track ids for artist Wet Leg (2TwOrUcYnAlIiKmVQkkoSZ)
Have newest track ids for artist 2TwOrUcYnAlIiKmVQkkoSZ
Warming cache for day 2/4 for artist 13/39...
Have top track ids for artist Hot Mulligan (1lKZzN2d4IqiEYxyECIEHI)
Have setlist track ids for artist Hot Mulligan (1lKZzN2d4IqiEYxyECIEHI)
Have newest track ids for artist 1lKZzN2d4IqiEYxyECIEHI
Warming cache for day 2/4 for artist 14/39...
Have top track ids for artist bbno$ (41X1TR6hrK8Q2ZCpp2EqCz)
Have setlist track ids for artist bbno$ (41X1TR6hrK8Q2ZCpp2EqCz)
Have top track ids for artist bbno$ (41X1TR6hrK8Q2ZCpp2EqCz)
Have newest track ids for artist 41X1TR6hrK8Q2ZCpp2EqCz
Warming cache for day 2/4 for artist 15/39...
Have top track ids for artist Zack Fox (1UH80jhsYsFztK0anu2FNS)
Have setlist track ids for artist Zack Fox (1UH80jhsYsFztK0anu2FNS)
Have top track ids for artist Zack Fox (1UH80jhsYsFztK0anu2FNS)
Have newest track ids for artist 1UH80jhsYsFztK0anu2FNS
Warming cache for day 2/4 for artist 16/39...
Have top track ids for artist Smino (1ybINI1qPiFbwDXamRtwxD)
Have setlist track ids for artist Smino (1ybINI1qPiFbwDXamRtwxD)
Have newest track ids for artist 1ybINI1qPiFbwDXamRtwxD
Warming cache for day 2/4 for artist 17/39...
Have top track ids for artist SIDEPIECE (5czbzNZZfWpyFgZyfT3Mkk)
Have setlist track ids for artist SIDEPIECE (5czbzNZZfWpyFgZyfT3Mkk)
Have top track ids for artist SIDEPIECE (5czbzNZZfWpyFgZyfT3Mkk)
Have newest track ids for artist 5czbzNZZfWpyFgZyfT3Mkk
Warming cache for day 2/4 for artist 18/39...
Have top track ids for artist Rachel Chinouriri (4wrzxtBZw20ufDstKyTnnP)
Have setlist track ids for artist Rachel Chinouriri (4wrzxtBZw20ufDstKyTnnP)
Have newest track ids for artist 4wrzxtBZw20ufDstKyTnnP
Warming cache for day 2/4 for artist 19/39...
Have top track ids for artist The Dare (2mqiqsaX4LzFnUP7PmHGAb)
Have setlist track ids for artist The Dare (2mqiqsaX4LzFnUP7PmHGAb)
Have newest track ids for artist 2mqiqsaX4LzFnUP7PmHGAb
Warming cache for day 2/4 for artist 20/39...
Have top track ids for artist Adventure Club (5CdJjUi9f0cVgo9nFuJrFa)
Have setlist track ids for artist Adventure Club (5CdJjUi9f0cVgo9nFuJrFa)
Have top track ids for artist Adventure Club (5CdJjUi9f0cVgo9nFuJrFa)
Have newest track ids for artist 5CdJjUi9f0cVgo9nFuJrFa
Warming cache for day 2/4 for artist 21/39...
Have top track ids for artist NOTION (1uRVM0wBdtyEuU582EeKJM)
Have setlist track ids for artist NOTION (1uRVM0wBdtyEuU582EeKJM)
Have top track ids for artist NOTION (1uRVM0wBdtyEuU582EeKJM)
Have newest track ids for artist 1uRVM0wBdtyEuU582EeKJM
Warming cache for day 2/4 for artist 22/39...
Have top track ids for artist Mother Mother (0e86yPdC41PGRkLp2Q1Bph)
Have setlist track ids for artist Mother Mother (0e86yPdC41PGRkLp2Q1Bph)
Have newest track ids for artist 0e86yPdC41PGRkLp2Q1Bph
Warming cache for day 2/4 for artist 23/39...
Have top track ids for artist Åaszewo (6jxGLrn1I14RIeRYodOpLN)
Have setlist track ids for artist Åaszewo (6jxGLrn1I14RIeRYodOpLN)
Have newest track ids for artist 6jxGLrn1I14RIeRYodOpLN
Warming cache for day 2/4 for artist 24/39...
Have top track ids for artist Blues Traveler (3pHeBYl1yujXcZqqfF1UyQ)
Have setlist track ids for artist Blues Traveler (3pHeBYl1yujXcZqqfF1UyQ)
Have top track ids for artist Blues Traveler (3pHeBYl1yujXcZqqfF1UyQ)
Have newest track ids for artist 3pHeBYl1yujXcZqqfF1UyQ
Warming cache for day 2/4 for artist 25/39...
Have top track ids for artist Wolfmother (3yEnArbNHyTCwMRvD9SBy4)
Have setlist track ids for artist Wolfmother (3yEnArbNHyTCwMRvD9SBy4)
Have newest track ids for artist 3yEnArbNHyTCwMRvD9SBy4
Warming cache for day 2/4 for artist 26/39...
Have top track ids for artist Wednesday (4j7DrazfBZLLD0OrVoAtEe)
Have setlist track ids for artist Wednesday (4j7DrazfBZLLD0OrVoAtEe)
Have newest track ids for artist 4j7DrazfBZLLD0OrVoAtEe
Warming cache for day 2/4 for artist 27/39...
Have top track ids for artist The Chats (1aQ7P3HtKOQFW16ebjiks1)
Have setlist track ids for artist The Chats (1aQ7P3HtKOQFW16ebjiks1)
Have newest track ids for artist 1aQ7P3HtKOQFW16ebjiks1
Warming cache for day 2/4 for artist 28/39...
Have top track ids for artist Lambrini Girls (6VR4TJ20WGiho2xZWMuuWb)
Have setlist track ids for artist Lambrini Girls (6VR4TJ20WGiho2xZWMuuWb)
Have newest track ids for artist 6VR4TJ20WGiho2xZWMuuWb
Warming cache for day 2/4 for artist 29/39...
Have top track ids for artist Amble (5ZC7GPz5h9zkEfjZBUDNzI)
Have setlist track ids for artist Amble (5ZC7GPz5h9zkEfjZBUDNzI)
Have newest track ids for artist 5ZC7GPz5h9zkEfjZBUDNzI
Warming cache for day 2/4 for artist 30/39...
Have top track ids for artist Daniel Allan (5JQ1XqKJ2Art01rF4tu1Ra)
Have setlist track ids for artist Daniel Allan (5JQ1XqKJ2Art01rF4tu1Ra)
Have top track ids for artist Daniel Allan (5JQ1XqKJ2Art01rF4tu1Ra)
Have newest track ids for artist 5JQ1XqKJ2Art01rF4tu1Ra
Warming cache for day 2/4 for artist 31/39...
Have top track ids for artist Goldie Boutilier (392WuM1Yb4QRI0GG4epyn5)
Have setlist track ids for artist Goldie Boutilier (392WuM1Yb4QRI0GG4epyn5)
Have top track ids for artist Goldie Boutilier (392WuM1Yb4QRI0GG4epyn5)
Have newest track ids for artist 392WuM1Yb4QRI0GG4epyn5
Warming cache for day 2/4 for artist 32/39...
Have top track ids for artist Dora Jar (4V30Q8ACPdJCcAmAYibfrH)
Have setlist track ids for artist Dora Jar (4V30Q8ACPdJCcAmAYibfrH)
Have newest track ids for artist 4V30Q8ACPdJCcAmAYibfrH
Warming cache for day 2/4 for artist 33/39...
Have top track ids for artist VILLANELLE (3J9QwmRJDdn9Oq1fB6mfcF)
Have setlist track ids for artist VILLANELLE (3J9QwmRJDdn9Oq1fB6mfcF)
Have top track ids for artist VILLANELLE (3J9QwmRJDdn9Oq1fB6mfcF)
Have newest track ids for artist 3J9QwmRJDdn9Oq1fB6mfcF
Warming cache for day 2/4 for artist 34/39...
Have top track ids for artist Jackie Hollander (5ykY9Uweo3gl5VFpb6z6pQ)
Have setlist track ids for artist Jackie Hollander (5ykY9Uweo3gl5VFpb6z6pQ)
Have top track ids for artist Jackie Hollander (5ykY9Uweo3gl5VFpb6z6pQ)
Have newest track ids for artist 5ykY9Uweo3gl5VFpb6z6pQ
Warming cache for day 2/4 for artist 35/39...
Have top track ids for artist PawPaw Rod (23KIrX6iPiVOkx60F4bjNq)
Have setlist track ids for artist PawPaw Rod (23KIrX6iPiVOkx60F4bjNq)
Have newest track ids for artist 23KIrX6iPiVOkx60F4bjNq
Warming cache for day 2/4 for artist 36/39...
No last updated date for top tracks for artist 1ZbT8FIqEc0cktnu6mNlvv found
No/out of date top track ids for spotify artist 1ZbT8FIqEc0cktnu6mNlvv, getting from spot, saving to redis artist, and saving each track. lastUpdated: never
No last updated date for setlist tracks for artist 1ZbT8FIqEc0cktnu6mNlvv found
Looking for setlist tracks for the first time, or refresh is due. lastUpdated: never
Received 12 tracks from setlists for EAZYBAKED (1ZbT8FIqEc0cktnu6mNlvv)
No last updated date for newest tracks for artist 1ZbT8FIqEc0cktnu6mNlvv found
No/out of date newest track ids for spotify artist 1ZbT8FIqEc0cktnu6mNlvv, getting albums from spot, saving to redis albums, then getting tracks from most recent album and saving each track. lastUpdated: never
Warming cache for day 2/4 for artist 37/39...
No last updated date for top tracks for artist 0y5sfSvE19x3r3nVUKYbIN found
No/out of date top track ids for spotify artist 0y5sfSvE19x3r3nVUKYbIN, getting from spot, saving to redis artist, and saving each track. lastUpdated: never
No last updated date for setlist tracks for artist 0y5sfSvE19x3r3nVUKYbIN found
Looking for setlist tracks for the first time, or refresh is due. lastUpdated: never
No/out of date top track ids for spotify artist 0y5sfSvE19x3r3nVUKYbIN, getting from spot, saving to redis artist, and saving each track. lastUpdated: 2026-02-24T16:39:25.070Z
Received 0 tracks from setlists for Lumasi (0y5sfSvE19x3r3nVUKYbIN), supplemented with 10 top tracks
No last updated date for newest tracks for artist 0y5sfSvE19x3r3nVUKYbIN found
No/out of date newest track ids for spotify artist 0y5sfSvE19x3r3nVUKYbIN, getting albums from spot, saving to redis albums, then getting tracks from most recent album and saving each track. lastUpdated: never
Got a 429, backing off for 1 seconds
Warming cache for day 2/4 for artist 38/39...
No/out of date top track ids for spotify artist 4tPVnr7VB15UA9TRsie3cS, getting from spot, saving to redis artist, and saving each track. lastUpdated: 2025-03-31T01:04:51.612Z
Looking for setlist tracks for the first time, or refresh is due. lastUpdated: 2025-03-31T01:04:51.531Z
Have top track ids for artist Mary Droppinz (4tPVnr7VB15UA9TRsie3cS)
Received 0 tracks from setlists for Mary Droppinz (4tPVnr7VB15UA9TRsie3cS), supplemented with 10 top tracks
No/out of date newest track ids for spotify artist 4tPVnr7VB15UA9TRsie3cS, getting albums from spot, saving to redis albums, then getting tracks from most recent album and saving each track. lastUpdated: 2025-03-31T01:04:52.350Z
Warming cache for day 2/4 for artist 39/39...
No last updated date for top tracks for artist 1ZcfGrGrm9aHnUNVQz3sCY found
No/out of date top track ids for spotify artist 1ZcfGrGrm9aHnUNVQz3sCY, getting from spot, saving to redis artist, and saving each track. lastUpdated: never
No last updated date for setlist tracks for artist 1ZcfGrGrm9aHnUNVQz3sCY found
Looking for setlist tracks for the first time, or refresh is due. lastUpdated: never
No/out of date top track ids for spotify artist 1ZcfGrGrm9aHnUNVQz3sCY, getting from spot, saving to redis artist, and saving each track. lastUpdated: 2026-02-24T16:39:36.796Z
Received 1 tracks from setlists for ProbCause (1ZcfGrGrm9aHnUNVQz3sCY), supplemented with 9 top tracks
No last updated date for newest tracks for artist 1ZcfGrGrm9aHnUNVQz3sCY found
No/out of date newest track ids for spotify artist 1ZcfGrGrm9aHnUNVQz3sCY, getting albums from spot, saving to redis albums, then getting tracks from most recent album and saving each track. lastUpdated: never
Received 40 artists from 40 lineup artists
festival:bonnaroo_2026:3
Reply: OK
Warming cache for day 3/4 for artist 1/40...
Have top track ids for artist RÃœFÃœS DU SOL (5Pb27ujIyYb33zBqVysBkj)
Have setlist track ids for artist RÃœFÃœS DU SOL (5Pb27ujIyYb33zBqVysBkj)
Have newest track ids for artist 5Pb27ujIyYb33zBqVysBkj
Warming cache for day 3/4 for artist 2/40...
Have top track ids for artist Teddy Swims (33qOK5uJ8AR2xuQQAhHump)
Have setlist track ids for artist Teddy Swims (33qOK5uJ8AR2xuQQAhHump)
Have newest track ids for artist 33qOK5uJ8AR2xuQQAhHump
Warming cache for day 3/4 for artist 3/40...
Have top track ids for artist The Neighbourhood (77SW9BnxLY8rJ0RciFqkHh)
Have setlist track ids for artist The Neighbourhood (77SW9BnxLY8rJ0RciFqkHh)
Have newest track ids for artist 77SW9BnxLY8rJ0RciFqkHh
Warming cache for day 3/4 for artist 4/40...
Have top track ids for artist Alabama Shakes (16GcWuvvybAoaHr0NqT8Eh)
Have setlist track ids for artist Alabama Shakes (16GcWuvvybAoaHr0NqT8Eh)
Have newest track ids for artist 16GcWuvvybAoaHr0NqT8Eh
Warming cache for day 3/4 for artist 5/40...
Have top track ids for artist Chase & Status (3jNkaOXasoc7RsxdchvEVq)
Have setlist track ids for artist Chase & Status (3jNkaOXasoc7RsxdchvEVq)
Have newest track ids for artist 3jNkaOXasoc7RsxdchvEVq
Warming cache for day 3/4 for artist 6/40...
Have top track ids for artist Sara Landry (7eILArMiTFTQf8SEh5fFHK)
Have setlist track ids for artist Sara Landry (7eILArMiTFTQf8SEh5fFHK)
Have top track ids for artist Sara Landry (7eILArMiTFTQf8SEh5fFHK)
Have newest track ids for artist 7eILArMiTFTQf8SEh5fFHK
Warming cache for day 3/4 for artist 7/40...
Have top track ids for artist Rainbow Kitten Surprise (4hz8tIajF2INpgM0qzPJz2)
Have setlist track ids for artist Rainbow Kitten Surprise (4hz8tIajF2INpgM0qzPJz2)
Have newest track ids for artist 4hz8tIajF2INpgM0qzPJz2
Warming cache for day 3/4 for artist 8/40...
Have top track ids for artist Freddie Gibbs (0Y4inQK6OespitzD6ijMwb)
Have setlist track ids for artist Freddie Gibbs (0Y4inQK6OespitzD6ijMwb)
Have newest track ids for artist 0Y4inQK6OespitzD6ijMwb
Warming cache for day 3/4 for artist 9/40...
Have top track ids for artist The Alchemist (0eVyjRhzZKke2KFYTcDkeu)
Have setlist track ids for artist The Alchemist (0eVyjRhzZKke2KFYTcDkeu)
Have top track ids for artist The Alchemist (0eVyjRhzZKke2KFYTcDkeu)
Have newest track ids for artist 0eVyjRhzZKke2KFYTcDkeu
Warming cache for day 3/4 for artist 10/40...
Have top track ids for artist Amyl and The Sniffers (3NqV2DJoAWsjl787bWaHW7)
Have setlist track ids for artist Amyl and The Sniffers (3NqV2DJoAWsjl787bWaHW7)
Have newest track ids for artist 3NqV2DJoAWsjl787bWaHW7
Warming cache for day 3/4 for artist 11/40...
Have top track ids for artist Sub Focus (0QaSiI5TLA4N7mcsdxShDO)
Have setlist track ids for artist Sub Focus (0QaSiI5TLA4N7mcsdxShDO)
Have top track ids for artist Sub Focus (0QaSiI5TLA4N7mcsdxShDO)
Have newest track ids for artist 0QaSiI5TLA4N7mcsdxShDO
Warming cache for day 3/4 for artist 12/40...
Have top track ids for artist Gorgon City (4VNQWV2y1E97Eqo2D5UTjx)
Have setlist track ids for artist Gorgon City (4VNQWV2y1E97Eqo2D5UTjx)
Have top track ids for artist Gorgon City (4VNQWV2y1E97Eqo2D5UTjx)
Have newest track ids for artist 4VNQWV2y1E97Eqo2D5UTjx
Warming cache for day 3/4 for artist 13/40...
Have top track ids for artist flipturn (7FKTg75ADVMZgY3P9ZMRtH)
Have setlist track ids for artist flipturn (7FKTg75ADVMZgY3P9ZMRtH)
Have newest track ids for artist 7FKTg75ADVMZgY3P9ZMRtH
Warming cache for day 3/4 for artist 14/40...
Have top track ids for artist Passion Pit (7gjAu1qr5C2grXeQFFOGeh)
Have setlist track ids for artist Passion Pit (7gjAu1qr5C2grXeQFFOGeh)
Have top track ids for artist Passion Pit (7gjAu1qr5C2grXeQFFOGeh)
Have newest track ids for artist 7gjAu1qr5C2grXeQFFOGeh
Warming cache for day 3/4 for artist 15/40...
Have top track ids for artist Snow Strippers (6TsAG8Ve1icEC8ydeHm3C8)
Have setlist track ids for artist Snow Strippers (6TsAG8Ve1icEC8ydeHm3C8)
Have newest track ids for artist 6TsAG8Ve1icEC8ydeHm3C8
Warming cache for day 3/4 for artist 16/40...
Have top track ids for artist Tash Sultana (6zVFRTB0Y1whWyH7ZNmywf)
Have setlist track ids for artist Tash Sultana (6zVFRTB0Y1whWyH7ZNmywf)
Have newest track ids for artist 6zVFRTB0Y1whWyH7ZNmywf
Warming cache for day 3/4 for artist 17/40...
Have top track ids for artist Wyatt Flores (46lEQmDJLJeyltECJYJv1Y)
Have setlist track ids for artist Wyatt Flores (46lEQmDJLJeyltECJYJv1Y)
Have newest track ids for artist 46lEQmDJLJeyltECJYJv1Y
Warming cache for day 3/4 for artist 18/40...
Have top track ids for artist Boys Noize (62k5LKMhymqlDNo2DWOvvv)
Have setlist track ids for artist Boys Noize (62k5LKMhymqlDNo2DWOvvv)
Have top track ids for artist Boys Noize (62k5LKMhymqlDNo2DWOvvv)
Have newest track ids for artist 62k5LKMhymqlDNo2DWOvvv
Warming cache for day 3/4 for artist 19/40...
Have top track ids for artist Holly Humberstone (0nnYdIpahs41QiZ9MWp5Wx)
Have setlist track ids for artist Holly Humberstone (0nnYdIpahs41QiZ9MWp5Wx)
Have newest track ids for artist 0nnYdIpahs41QiZ9MWp5Wx
Warming cache for day 3/4 for artist 20/40...
Have top track ids for artist Deathpact (09C3CKFxKEw1n1Z7kvT3jb)
Have setlist track ids for artist Deathpact (09C3CKFxKEw1n1Z7kvT3jb)
Have top track ids for artist Deathpact (09C3CKFxKEw1n1Z7kvT3jb)
Have newest track ids for artist 09C3CKFxKEw1n1Z7kvT3jb
Warming cache for day 3/4 for artist 21/40...
Have top track ids for artist SG Lewis (0GG2cWaonE4JPrjcCCQ1EG)
Have setlist track ids for artist SG Lewis (0GG2cWaonE4JPrjcCCQ1EG)
Have newest track ids for artist 0GG2cWaonE4JPrjcCCQ1EG
Warming cache for day 3/4 for artist 22/40...
Have top track ids for artist Osees (0Ynh5WKqwbdYqJUpVpfEGS)
Have setlist track ids for artist Osees (0Ynh5WKqwbdYqJUpVpfEGS)
Have newest track ids for artist 0Ynh5WKqwbdYqJUpVpfEGS
Warming cache for day 3/4 for artist 23/40...
Have top track ids for artist Waylon Wyatt (6Ff2omMMZOd8FWNqb980Ol)
Have setlist track ids for artist Waylon Wyatt (6Ff2omMMZOd8FWNqb980Ol)
Have top track ids for artist Waylon Wyatt (6Ff2omMMZOd8FWNqb980Ol)
Have newest track ids for artist 6Ff2omMMZOd8FWNqb980Ol
Warming cache for day 3/4 for artist 24/40...
Have top track ids for artist The Runarounds (6G6I2kNqaE0oDRygzPRGeY)
Have setlist track ids for artist The Runarounds (6G6I2kNqaE0oDRygzPRGeY)
Have top track ids for artist The Runarounds (6G6I2kNqaE0oDRygzPRGeY)
Have newest track ids for artist 6G6I2kNqaE0oDRygzPRGeY
Warming cache for day 3/4 for artist 25/40...
Have top track ids for artist Trixie Mattel (33hAj1SghVYxDAxZxNDcyc)
Have setlist track ids for artist Trixie Mattel (33hAj1SghVYxDAxZxNDcyc)
Have top track ids for artist Trixie Mattel (33hAj1SghVYxDAxZxNDcyc)
Have newest track ids for artist 33hAj1SghVYxDAxZxNDcyc
Warming cache for day 3/4 for artist 26/40...
Have top track ids for artist Buffalo Traffic Jam (22LEPYRDhoThnbpShy6fV7)
Have setlist track ids for artist Buffalo Traffic Jam (22LEPYRDhoThnbpShy6fV7)
Have top track ids for artist Buffalo Traffic Jam (22LEPYRDhoThnbpShy6fV7)
Have newest track ids for artist 22LEPYRDhoThnbpShy6fV7
Warming cache for day 3/4 for artist 27/40...
Have top track ids for artist Confidence Man (0RwXnFrEoI8tltFvYpJgP6)
Have setlist track ids for artist Confidence Man (0RwXnFrEoI8tltFvYpJgP6)
Have newest track ids for artist 0RwXnFrEoI8tltFvYpJgP6
Warming cache for day 3/4 for artist 28/40...
Have top track ids for artist Arcy Drive (7o1TBmx7Ube5h2Czlam84O)
Have setlist track ids for artist Arcy Drive (7o1TBmx7Ube5h2Czlam84O)
Have newest track ids for artist 7o1TBmx7Ube5h2Czlam84O
Warming cache for day 3/4 for artist 29/40...
Have top track ids for artist Mountain Grass Unit (0FWlJ725NEZpxqxjZG3yGl)
Have setlist track ids for artist Mountain Grass Unit (0FWlJ725NEZpxqxjZG3yGl)
Have top track ids for artist Mountain Grass Unit (0FWlJ725NEZpxqxjZG3yGl)
Have newest track ids for artist 0FWlJ725NEZpxqxjZG3yGl
Warming cache for day 3/4 for artist 30/40...
Have top track ids for artist Juelz (04p1jV00pBnrmh2rKl0jnT)
Have setlist track ids for artist Juelz (04p1jV00pBnrmh2rKl0jnT)
Have newest track ids for artist 04p1jV00pBnrmh2rKl0jnT
Warming cache for day 3/4 for artist 31/40...
Have top track ids for artist The Stews (4yUYrN1PFyzwUDSzEpYYEi)
Have setlist track ids for artist The Stews (4yUYrN1PFyzwUDSzEpYYEi)
Have newest track ids for artist 4yUYrN1PFyzwUDSzEpYYEi
Warming cache for day 3/4 for artist 32/40...
Have top track ids for artist Congress The Band (4LuzeYhmxPW7iKWUXmyb10)
Have setlist track ids for artist Congress The Band (4LuzeYhmxPW7iKWUXmyb10)
Have top track ids for artist Congress The Band (4LuzeYhmxPW7iKWUXmyb10)
Have newest track ids for artist 4LuzeYhmxPW7iKWUXmyb10
Warming cache for day 3/4 for artist 33/40...
Have top track ids for artist Midnight Generation (4CKIGHCZRzNoiNDSaW5eaq)
Have setlist track ids for artist Midnight Generation (4CKIGHCZRzNoiNDSaW5eaq)
Have newest track ids for artist 4CKIGHCZRzNoiNDSaW5eaq
Warming cache for day 3/4 for artist 34/40...
Have top track ids for artist Sunami (1pBeRGeBHNPLy95LswDViS)
Have setlist track ids for artist Sunami (1pBeRGeBHNPLy95LswDViS)
Have newest track ids for artist 1pBeRGeBHNPLy95LswDViS
Warming cache for day 3/4 for artist 35/40...
Have top track ids for artist Nikita, the Wicked (0Kc65Qv0ju9H2cMNnP3Tqd)
Have setlist track ids for artist Nikita, the Wicked (0Kc65Qv0ju9H2cMNnP3Tqd)
Have top track ids for artist Nikita, the Wicked (0Kc65Qv0ju9H2cMNnP3Tqd)
Have newest track ids for artist 0Kc65Qv0ju9H2cMNnP3Tqd
Warming cache for day 3/4 for artist 36/40...
Have top track ids for artist "Weird Al" Yankovic (1bDWGdIC2hardyt55nlQgG)
Have setlist track ids for artist "Weird Al" Yankovic (1bDWGdIC2hardyt55nlQgG)
Have newest track ids for artist 1bDWGdIC2hardyt55nlQgG
Warming cache for day 3/4 for artist 37/40...
Have top track ids for artist Big Gigantic (7o7mC95EDbJKTcPAAs8C3r)
Have setlist track ids for artist Big Gigantic (7o7mC95EDbJKTcPAAs8C3r)
Have newest track ids for artist 7o7mC95EDbJKTcPAAs8C3r
Warming cache for day 3/4 for artist 38/40...
Have top track ids for artist CloZee (1496XxkytEk26FUJLfpVZr)
Have setlist track ids for artist CloZee (1496XxkytEk26FUJLfpVZr)
Have top track ids for artist CloZee (1496XxkytEk26FUJLfpVZr)
Have newest track ids for artist 1496XxkytEk26FUJLfpVZr
Warming cache for day 3/4 for artist 39/40...
No/out of date top track ids for spotify artist 6l0u1oM2imxw0isrGcXpmH, getting from spot, saving to redis artist, and saving each track. lastUpdated: 2025-03-31T00:58:44.983Z
Looking for setlist tracks for the first time, or refresh is due. lastUpdated: 2025-03-31T00:58:44.864Z
Have top track ids for artist Effin (6l0u1oM2imxw0isrGcXpmH)
Received 0 tracks from setlists for Effin (6l0u1oM2imxw0isrGcXpmH), supplemented with 10 top tracks
No/out of date newest track ids for spotify artist 6l0u1oM2imxw0isrGcXpmH, getting albums from spot, saving to redis albums, then getting tracks from most recent album and saving each track. lastUpdated: 2025-03-31T00:58:45.635Z
Warming cache for day 3/4 for artist 40/40...
No last updated date for top tracks for artist 6409kgOB4tZEkNZci6BiUs found
No/out of date top track ids for spotify artist 6409kgOB4tZEkNZci6BiUs, getting from spot, saving to redis artist, and saving each track. lastUpdated: never
No last updated date for setlist tracks for artist 6409kgOB4tZEkNZci6BiUs found
Looking for setlist tracks for the first time, or refresh is due. lastUpdated: never
No/out of date top track ids for spotify artist 6409kgOB4tZEkNZci6BiUs, getting from spot, saving to redis artist, and saving each track. lastUpdated: 2026-02-24T16:39:46.782Z
Received 2 tracks from setlists for Smoakland (6409kgOB4tZEkNZci6BiUs), supplemented with 8 top tracks
No last updated date for newest tracks for artist 6409kgOB4tZEkNZci6BiUs found
No/out of date newest track ids for spotify artist 6409kgOB4tZEkNZci6BiUs, getting albums from spot, saving to redis albums, then getting tracks from most recent album and saving each track. lastUpdated: never
Received 27 artists from 27 lineup artists
festival:bonnaroo_2026:4
Reply: OK
Warming cache for day 4/4 for artist 1/27...
Have top track ids for artist Noah Kahan (2RQXRUsr4IW1f3mKyKsy4B)
Have setlist track ids for artist Noah Kahan (2RQXRUsr4IW1f3mKyKsy4B)
Have newest track ids for artist 2RQXRUsr4IW1f3mKyKsy4B
Warming cache for day 4/4 for artist 2/27...
Have top track ids for artist ROLE MODEL (1dy5WNgIKQU6ezkpZs4y8z)
Have setlist track ids for artist ROLE MODEL (1dy5WNgIKQU6ezkpZs4y8z)
Have newest track ids for artist 1dy5WNgIKQU6ezkpZs4y8z
Warming cache for day 4/4 for artist 3/27...
Have top track ids for artist Kesha (6LqNN22kT3074XbTVUrhzX)
Have setlist track ids for artist Kesha (6LqNN22kT3074XbTVUrhzX)
Have newest track ids for artist 6LqNN22kT3074XbTVUrhzX
Warming cache for day 4/4 for artist 4/27...
Have top track ids for artist Tedeschi Trucks Band (2gFsmDBM0hkoZPmrO5EdyO)
Have setlist track ids for artist Tedeschi Trucks Band (2gFsmDBM0hkoZPmrO5EdyO)
Have newest track ids for artist 2gFsmDBM0hkoZPmrO5EdyO
Warming cache for day 4/4 for artist 5/27...
Have top track ids for artist CloZee (1496XxkytEk26FUJLfpVZr)
Have setlist track ids for artist CloZee (1496XxkytEk26FUJLfpVZr)
Have top track ids for artist CloZee (1496XxkytEk26FUJLfpVZr)
Have newest track ids for artist 1496XxkytEk26FUJLfpVZr
Warming cache for day 4/4 for artist 6/27...
Have top track ids for artist LSDREAM (3Hrqjumb6WHg2aAUHJHLND)
Have setlist track ids for artist LSDREAM (3Hrqjumb6WHg2aAUHJHLND)
Have top track ids for artist LSDREAM (3Hrqjumb6WHg2aAUHJHLND)
Have newest track ids for artist 3Hrqjumb6WHg2aAUHJHLND
Warming cache for day 4/4 for artist 7/27...
Have top track ids for artist Clipse (2J257euzcjnDLipsyJH3F2)
Have setlist track ids for artist Clipse (2J257euzcjnDLipsyJH3F2)
Have newest track ids for artist 2J257euzcjnDLipsyJH3F2
Warming cache for day 4/4 for artist 8/27...
Have top track ids for artist Mariah the Scientist (7HO5fOXE4gh3lzZn64tX2E)
Have setlist track ids for artist Mariah the Scientist (7HO5fOXE4gh3lzZn64tX2E)
Have newest track ids for artist 7HO5fOXE4gh3lzZn64tX2E
Warming cache for day 4/4 for artist 9/27...
Have top track ids for artist Daily Bread (4IsiG6RpDyRq6Frd2CvddW)
Have setlist track ids for artist Daily Bread (4IsiG6RpDyRq6Frd2CvddW)
Have top track ids for artist Daily Bread (4IsiG6RpDyRq6Frd2CvddW)
Have newest track ids for artist 4IsiG6RpDyRq6Frd2CvddW
Warming cache for day 4/4 for artist 10/27...
Have top track ids for artist Modest Mouse (1yAwtBaoHLEDWAnWR87hBT)
Have setlist track ids for artist Modest Mouse (1yAwtBaoHLEDWAnWR87hBT)
Have newest track ids for artist 1yAwtBaoHLEDWAnWR87hBT
Warming cache for day 4/4 for artist 11/27...
Have top track ids for artist Big Gigantic (7o7mC95EDbJKTcPAAs8C3r)
Have setlist track ids for artist Big Gigantic (7o7mC95EDbJKTcPAAs8C3r)
Have newest track ids for artist 7o7mC95EDbJKTcPAAs8C3r
Warming cache for day 4/4 for artist 12/27...
Have top track ids for artist Japanese Breakfast (7MoIc5s9KXolCBH1fy9kkw)
Have setlist track ids for artist Japanese Breakfast (7MoIc5s9KXolCBH1fy9kkw)
Have newest track ids for artist 7MoIc5s9KXolCBH1fy9kkw
Warming cache for day 4/4 for artist 13/27...
Have top track ids for artist Turnover (0gLjJuczGWhqKVMmVpIT52)
Have setlist track ids for artist Turnover (0gLjJuczGWhqKVMmVpIT52)
Have newest track ids for artist 0gLjJuczGWhqKVMmVpIT52
Warming cache for day 4/4 for artist 14/27...
Have top track ids for artist San Holo (0jNDKefhfSbLR9sFvcPLHo)
Have setlist track ids for artist San Holo (0jNDKefhfSbLR9sFvcPLHo)
Have newest track ids for artist 0jNDKefhfSbLR9sFvcPLHo
Warming cache for day 4/4 for artist 15/27...
Have top track ids for artist Trombone Shorty (37ZvFp654tY74Z1D2TLOGR)
Have setlist track ids for artist Trombone Shorty (37ZvFp654tY74Z1D2TLOGR)
Have newest track ids for artist 37ZvFp654tY74Z1D2TLOGR
Warming cache for day 4/4 for artist 16/27...
Have top track ids for artist Del Water Gap (0xPoVNPnxIIUS1vrxAYV00)
Have setlist track ids for artist Del Water Gap (0xPoVNPnxIIUS1vrxAYV00)
Have newest track ids for artist 0xPoVNPnxIIUS1vrxAYV00
Warming cache for day 4/4 for artist 17/27...
Have top track ids for artist Spacey Jane (6V70yeZQCoSR2M3fyW8qiA)
Have setlist track ids for artist Spacey Jane (6V70yeZQCoSR2M3fyW8qiA)
Have newest track ids for artist 6V70yeZQCoSR2M3fyW8qiA
Warming cache for day 4/4 for artist 18/27...
Have top track ids for artist Audrey Hobert (4N0TAwz9vhnQtjCqS65aKS)
Have setlist track ids for artist Audrey Hobert (4N0TAwz9vhnQtjCqS65aKS)
Have newest track ids for artist 4N0TAwz9vhnQtjCqS65aKS
Warming cache for day 4/4 for artist 19/27...
Have top track ids for artist Fcukers (3UtzOHYm3lQALkKzVD4wyO)
Have setlist track ids for artist Fcukers (3UtzOHYm3lQALkKzVD4wyO)
Have top track ids for artist Fcukers (3UtzOHYm3lQALkKzVD4wyO)
Have newest track ids for artist 3UtzOHYm3lQALkKzVD4wyO
Warming cache for day 4/4 for artist 20/27...
Have top track ids for artist Blondshell (7qrEXiLLnWkkYHhadZ1Oij)
Have setlist track ids for artist Blondshell (7qrEXiLLnWkkYHhadZ1Oij)
Have newest track ids for artist 7qrEXiLLnWkkYHhadZ1Oij
Warming cache for day 4/4 for artist 21/27...
Have top track ids for artist Little Stranger (6nheJ1XoAkaKOLIgHzMbTq)
Have setlist track ids for artist Little Stranger (6nheJ1XoAkaKOLIgHzMbTq)
Have newest track ids for artist 6nheJ1XoAkaKOLIgHzMbTq
Warming cache for day 4/4 for artist 22/27...
Have top track ids for artist Aly & AJ (5wugb0kaq0J6nyQ5Xgd17i)
Have setlist track ids for artist Aly & AJ (5wugb0kaq0J6nyQ5Xgd17i)
Have newest track ids for artist 5wugb0kaq0J6nyQ5Xgd17i
Warming cache for day 4/4 for artist 23/27...
Have top track ids for artist hemlocke springs (52PdgUJOjvS6Mpmjy1SAlx)
Have setlist track ids for artist hemlocke springs (52PdgUJOjvS6Mpmjy1SAlx)
Have newest track ids for artist 52PdgUJOjvS6Mpmjy1SAlx
Warming cache for day 4/4 for artist 24/27...
Have top track ids for artist Steph Strings (39qxIdIb1R6se4J3X6nRPB)
Have setlist track ids for artist Steph Strings (39qxIdIb1R6se4J3X6nRPB)
Have top track ids for artist Steph Strings (39qxIdIb1R6se4J3X6nRPB)
Have newest track ids for artist 39qxIdIb1R6se4J3X6nRPB
Warming cache for day 4/4 for artist 25/27...
Have top track ids for artist A Hundred Drums (1dUCaUhp2RZRXrwOyUnHxQ)
Have setlist track ids for artist A Hundred Drums (1dUCaUhp2RZRXrwOyUnHxQ)
Have top track ids for artist A Hundred Drums (1dUCaUhp2RZRXrwOyUnHxQ)
Have newest track ids for artist 1dUCaUhp2RZRXrwOyUnHxQ
Warming cache for day 4/4 for artist 26/27...
Have top track ids for artist Girl Tones (1Tq0nryXkwLARcHDMIZbY6)
Have setlist track ids for artist Girl Tones (1Tq0nryXkwLARcHDMIZbY6)
Have top track ids for artist Girl Tones (1Tq0nryXkwLARcHDMIZbY6)
Have newest track ids for artist 1Tq0nryXkwLARcHDMIZbY6
Warming cache for day 4/4 for artist 27/27...
Have top track ids for artist Motifv (3Q3g3xC2lDdLo3a04uK3Wp)
Have setlist track ids for artist Motifv (3Q3g3xC2lDdLo3a04uK3Wp)
Have top track ids for artist Motifv (3Q3g3xC2lDdLo3a04uK3Wp)
Have newest track ids for artist 3Q3g3xC2lDdLo3a04uK3Wp
```
</details>